### PR TITLE
Integrate cart and order flow

### DIFF
--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -3,22 +3,27 @@ import Header from './components/Header'
 import Home from './pages/Home'
 import Catalog from './pages/Catalog'
 import ProductPage from './pages/ProductPage'
+import CartPage from './pages/CartPage'
 import About from './pages/About'
 import ForBuyers from './pages/ForBuyers'
+import { CartProvider } from './components/CartContext'
 
 export default function App() {
   return (
-    <BrowserRouter>
-      <Header />
-      <main>
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/catalog" element={<Catalog />} />
-          <Route path="/product/:id" element={<ProductPage />} />
-          <Route path="/about" element={<About />} />
-          <Route path="/buyers" element={<ForBuyers />} />
-        </Routes>
-      </main>
-    </BrowserRouter>
+    <CartProvider>
+      <BrowserRouter>
+        <Header />
+        <main>
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/catalog" element={<Catalog />} />
+            <Route path="/product/:id" element={<ProductPage />} />
+            <Route path="/cart" element={<CartPage />} />
+            <Route path="/about" element={<About />} />
+            <Route path="/buyers" element={<ForBuyers />} />
+          </Routes>
+        </main>
+      </BrowserRouter>
+    </CartProvider>
   )
 }

--- a/app/src/api.js
+++ b/app/src/api.js
@@ -1,0 +1,1 @@
+export const API_BASE = 'http://localhost:8080'

--- a/app/src/components/CartContext.jsx
+++ b/app/src/components/CartContext.jsx
@@ -1,0 +1,19 @@
+import { createContext, useContext, useState } from 'react'
+
+const CartContext = createContext()
+
+export function CartProvider({ children }) {
+  const [items, setItems] = useState([])
+
+  const addToCart = (product) => setItems((prev) => [...prev, product])
+  const removeFromCart = (id) => setItems((prev) => prev.filter((p) => p.id !== id))
+  const clearCart = () => setItems([])
+
+  return (
+    <CartContext.Provider value={{ items, addToCart, removeFromCart, clearCart }}>
+      {children}
+    </CartContext.Provider>
+  )
+}
+
+export const useCart = () => useContext(CartContext)

--- a/app/src/components/Header.jsx
+++ b/app/src/components/Header.jsx
@@ -1,9 +1,11 @@
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import logo from '../Logo.svg'
+import { useCart } from './CartContext'
 
 export default function Header() {
   const [open, setOpen] = useState(false)
+  const { items } = useCart()
 
   const close = () => setOpen(false)
 
@@ -11,6 +13,7 @@ export default function Header() {
     <>
       <header className="header">
         <img src={logo} alt="FLO logo" className="logo" />
+        <Link to="/cart">Корзина ({items.length})</Link>
         <button className="menu-button" onClick={() => setOpen(true)} aria-label="Открыть меню">
           &#9776;
         </button>
@@ -25,6 +28,7 @@ export default function Header() {
             <Link to="/catalog" onClick={close}>Каталог</Link>
             <Link to="/about" onClick={close}>О проекте</Link>
             <Link to="/buyers" onClick={close}>Покупателям</Link>
+            <Link to="/cart" onClick={close}>Корзина ({items.length})</Link>
           </div>
         </nav>
       )}

--- a/app/src/components/ProductCard.jsx
+++ b/app/src/components/ProductCard.jsx
@@ -1,11 +1,19 @@
+import { Link } from 'react-router-dom'
+import { useCart } from './CartContext'
+
 export default function ProductCard({ product }) {
+  const { addToCart } = useCart()
+
   return (
     <div className="product-card">
-      {product.photos && product.photos[0] && (
-        <img src={product.photos[0]} alt={product.name} />
-      )}
-      <h3>{product.name}</h3>
+      <Link to={`/product/${product.id}`}>
+        {product.photos && product.photos[0] && (
+          <img src={product.photos[0]} alt={product.name} />
+        )}
+        <h3>{product.name}</h3>
+      </Link>
       <p>{product.price} ₽</p>
+      <button onClick={() => addToCart(product)}>В корзину</button>
     </div>
   )
 }

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -92,3 +92,16 @@ main {
   width: 100%;
   height: auto;
 }
+
+.order-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.order-form input,
+.order-form textarea {
+  padding: 0.5rem;
+  font-size: 1rem;
+}

--- a/app/src/pages/CartPage.jsx
+++ b/app/src/pages/CartPage.jsx
@@ -1,0 +1,102 @@
+import { useState } from 'react'
+import { useCart } from '../components/CartContext'
+import { API_BASE } from '../api'
+
+export default function CartPage() {
+  const { items, removeFromCart, clearCart } = useCart()
+  const [form, setForm] = useState({
+    name: '',
+    phone: '',
+    telegram: '',
+    email: '',
+    comment: '',
+  })
+  const [submitted, setSubmitted] = useState(false)
+
+  const handleChange = (e) => {
+    const { name, value } = e.target
+    setForm((f) => ({ ...f, [name]: value }))
+  }
+
+  const handleSubmit = (e) => {
+    e.preventDefault()
+    const order = {
+      customerName: form.name,
+      productIds: items.map((i) => i.id),
+    }
+    if (form.phone) order.phone = form.phone
+    if (form.telegram) order.telegramUsername = form.telegram
+    if (form.email) order.email = form.email
+    if (form.comment) order.customerComment = form.comment
+
+    fetch(`${API_BASE}/api/orders`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(order),
+    })
+      .then((r) => {
+        if (r.ok) {
+          clearCart()
+          setSubmitted(true)
+        }
+      })
+      .catch((e) => console.error(e))
+  }
+
+  if (submitted) return <h1>Спасибо за заказ!</h1>
+
+  return (
+    <div>
+      <h1>Корзина</h1>
+      {items.length === 0 ? (
+        <p>Корзина пуста</p>
+      ) : (
+        <>
+          <ul>
+            {items.map((p) => (
+              <li key={p.id}>
+                {p.name} - {p.price} ₽{' '}
+                <button onClick={() => removeFromCart(p.id)}>Удалить</button>
+              </li>
+            ))}
+          </ul>
+          <h2>Оформление заказа</h2>
+          <form onSubmit={handleSubmit} className="order-form">
+            <input
+              name="name"
+              value={form.name}
+              onChange={handleChange}
+              placeholder="Имя"
+              required
+            />
+            <input
+              name="phone"
+              value={form.phone}
+              onChange={handleChange}
+              placeholder="Телефон"
+            />
+            <input
+              name="telegram"
+              value={form.telegram}
+              onChange={handleChange}
+              placeholder="Telegram"
+            />
+            <input
+              name="email"
+              value={form.email}
+              onChange={handleChange}
+              placeholder="Email"
+            />
+            <textarea
+              name="comment"
+              value={form.comment}
+              onChange={handleChange}
+              placeholder="Комментарий"
+            />
+            <button type="submit">Отправить</button>
+          </form>
+        </>
+      )}
+    </div>
+  )
+}

--- a/app/src/pages/Catalog.jsx
+++ b/app/src/pages/Catalog.jsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react'
 import ProductCard from '../components/ProductCard'
+import { API_BASE } from '../api'
 
 export default function Catalog() {
   const [products, setProducts] = useState([])
 
   useEffect(() => {
-    fetch('/api/products')
+    fetch(`${API_BASE}/api/products`)
       .then((r) => r.json())
       .then((data) => {
         if (Array.isArray(data)) setProducts(data)

--- a/app/src/pages/ProductPage.jsx
+++ b/app/src/pages/ProductPage.jsx
@@ -1,12 +1,15 @@
 import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
+import { API_BASE } from '../api'
+import { useCart } from '../components/CartContext'
 
 export default function ProductPage() {
   const { id } = useParams()
   const [product, setProduct] = useState(null)
+  const { addToCart } = useCart()
 
   useEffect(() => {
-    fetch(`/api/products/${id}`)
+    fetch(`${API_BASE}/api/products/${id}`)
       .then((r) => r.json())
       .then(setProduct)
       .catch((e) => console.error(e))
@@ -22,6 +25,7 @@ export default function ProductPage() {
       )}
       <p>{product.description}</p>
       <p>Цена: {product.price} ₽</p>
+      <button onClick={() => addToCart(product)}>Добавить в корзину</button>
     </div>
   )
 }

--- a/app/vite.config.js
+++ b/app/vite.config.js
@@ -4,4 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8080',
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- connect to backend API via new API_BASE constant
- enable proxy for `/api` in Vite dev server
- implement cart state and add Cart page
- link cart in header and allow adding products to cart
- show product pages with add-to-cart button
- style order form for submitting orders

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d3548e58c832388c185efe1cf8e7c